### PR TITLE
fix: ensure proper naming of rbac components

### DIFF
--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: controller-manager-rolebinding
+  name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller-manager-role
+  name: manager-role
 subjects:
   - kind: ServiceAccount
     name: default
@@ -18,7 +18,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller-manager-role
+  name: manager-role
 subjects:
   - kind: ServiceAccount
     name: default
@@ -31,7 +31,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller-manager-role
+  name: manager-role
 subjects:
   - kind: ServiceAccount
     name: default


### PR DESCRIPTION
This PR will fix naming of the rbac components to make sure they get the
`capm-` prefix properly and things just work (tm).