### PR TITLE
feat: add new release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,12 @@ ARG TAG
 RUN cd config/manager \
   && kustomize edit set image controller=${REGISTRY_AND_USERNAME}/${NAME}:${TAG} \
   && cd - \
-  && kubectl kustomize config/default >/release.yaml
+  && kubectl kustomize config/default >/infrastructure-components.yaml \
+  && cp config/metadata.yaml >/metadata.yaml
+
 FROM scratch AS release
-COPY --from=release-build /release.yaml /release.yaml
+COPY --from=release-build /infrastructure-components.yaml /infrastructure-components.yaml
+COPY --from=release-build /metadata.yaml /metadata.yaml
 
 FROM build AS binary
 RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -ldflags "-s -w" -o /manager

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ There are a few corequisites and assumptions that go into using this project:
 ## Building and Installing
 
 This project can be built simply by running `make release` from the root directory.
-Doing so will create a file called `_out/release.yaml`.
+Doing so will create a file called `_out/infrastructure-components.yaml`.
 If you wish, you can tweak settings by editing the release yaml.
-This file can then be installed into your management cluster with `kubectl apply -f _out/release.yaml`.
+This file can then be installed into your management cluster with `kubectl apply -f _out/infrastructure-components.yaml`.
 
 Note that CAPM should be deployed as part of a set of controllers for Cluster API.
 You will need at least the upstream CAPI components and a bootstrap provider for v1alpha2 CAPI capabilities.

--- a/config/metadata/metadata.yaml
+++ b/config/metadata/metadata.yaml
@@ -1,0 +1,6 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 1
+  contract: v1alpha2


### PR DESCRIPTION
This PR will move to publishing infrastructure-components.yaml and
metdata.yaml upon tagging a release so that clusterctl can consume
them.