### PR TITLE
fix: only set ipmi poweron if chassis reports it's off

### DIFF
--- a/controllers/metalmachine_controller.go
+++ b/controllers/metalmachine_controller.go
@@ -141,14 +141,23 @@ func (r *MetalMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rer
 			return ctrl.Result{}, err
 		}
 
-		err = ipmiClient.SetPXE()
+		chassisStatus, err := ipmiClient.Status()
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
-		err = ipmiClient.PowerOn()
-		if err != nil {
-			return ctrl.Result{}, err
+		// Only take action if server is turned off
+		// otherwise IPMI library gets angry
+		if !chassisStatus.IsSystemPowerOn() {
+			err = ipmiClient.SetPXE()
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			err = ipmiClient.PowerOn()
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the ipmi library was barfing if we issued
poweron while the node was already powered on.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>